### PR TITLE
#51: Fix nav menu

### DIFF
--- a/components/header/HeaderQuery.graphql
+++ b/components/header/HeaderQuery.graphql
@@ -2,7 +2,7 @@ query MainMenuQuery {
   # TODO: one level up, nice and specific, theme-independent, and can be used
   # for header and footer menu queries:
   # menu(id: "main", idType: NAME) { menuItems }
-  menuItems(where: { location: PRIMARY, parentId: "" }) {
+  menuItems(where: { location: PRIMARY, parentId: 0 }) {
     nodes {
       ...MenuBits
       childItems(first: 200) {


### PR DESCRIPTION
closes #51 

problem was a result of WP graphql plugin upgrade, which we want, but it broke our things. all set now 🤞 